### PR TITLE
Add missing depends for executable 'core'.

### DIFF
--- a/src/nikki.cabal
+++ b/src/nikki.cabal
@@ -154,6 +154,8 @@ Executable core
         , uniplate >= 1.6
         , utf8-string == 0.3.*
         , vector == 0.10.*
+        , string-conversions == 0.3.0.3
+        , network-uri == 2.6.0.1
 
     if os(linux)
         extra-libraries:


### PR DESCRIPTION
I added two missing dependencies for executable 'core' that prevented me from compiling.

The version numbers are precise as I don't know what other versions may work. Feel free to decline the pull request in order to make a better fix by yourself then.